### PR TITLE
Treat consecutive wildcards as one

### DIFF
--- a/lib/wildcard_to_regex.ex
+++ b/lib/wildcard_to_regex.ex
@@ -19,6 +19,7 @@ defmodule Wildcard do
   def to_regex(expression) do
     {:ok, regex} = expression
       |> String.split("*")
+      |> Enum.filter(&(&1 != ""))
       |> Enum.map(&Regex.escape(&1))
       |> Enum.join(".*")
       |> Regex.compile

--- a/test/wildcard_to_regex_test.exs
+++ b/test/wildcard_to_regex_test.exs
@@ -20,5 +20,9 @@ defmodule WildcardTest do
     test "properly escapes a string containing a special regex operator" do
       assert to_regex("cat.dog/+") == ~r/cat\.dog\/\+/
     end
+
+    test "treats consecutive wildcards as one" do
+      assert to_regex("cat***dog") == ~r/cat.*dog/
+    end
   end
 end


### PR DESCRIPTION
Treat multiple consecutive wildcards as one to avoid confusion (as technically the regex would work fine).