### PR TITLE
Add options

### DIFF
--- a/lib/wildcard_to_regex.ex
+++ b/lib/wildcard_to_regex.ex
@@ -1,28 +1,65 @@
 defmodule Wildcard do
   @moduledoc """
-  Wildcard is a module that can be used to interact with wildcard statements
-  intended to match text
+  Provides functions for dealing with wildcard expressions which are intended to
+  match agains strings.
+
+  A wildcard expression is a string that contains `*` characters which indicate
+  that any text can be substituted at the location of the `*` characters. An
+  example of a wildcard expression would be `"ch*se"`, which would match
+  `"cheese"`, but not `"cats"`.
+
+  ## Options
+
+  The following options can be specified for the functions in the Wildcard
+  module:
+
+    * `match_type` - determines what will be matched by a wildcard character.
+      The default is `:one_or_more`
+      * `:one_or_more` - Matches one or more characters.
+      * `:zero_or_more` - Matches any number of characters or none at all.
+      * `:one` - Matches exactly one character.
   """
 
   @doc """
   Converts an expression that can contain wildcards into a regex that can be
-  used to match text. The resulting regex does not anchor to the beginning or
+  used to match text.
+
+  The resulting regex does not anchor to the beginning or
   end of the string using ^ or $. All non-wildcard text in the given expression
   is converted to raw text.
 
-  ## Example
+  ## Examples
 
       iex> Wildcard.to_regex("man*pig")
+      ~r/man.+pig/
+
+      iex> Wildcard.to_regex("man*pig", match_type: :zero_or_more)
       ~r/man.*pig/
 
+      iex> Wildcard.to_regex("man****pig", match_type: :one)
+      ~r/man....pig/
+
   """
-  def to_regex(expression) do
+  @spec to_regex(String.t, Keyword.t) :: Regex.t
+  def to_regex(expression, opts \\ []) do
+    match_type = Keyword.get(opts, :match_type)
+
     {:ok, regex} = expression
       |> String.split("*")
-      |> Enum.filter(&(&1 != ""))
       |> Enum.map(&Regex.escape(&1))
-      |> Enum.join(".*")
+      |> maybe_filter_empties(match_type)
+      |> join_with_quantifier(match_type)
       |> Regex.compile
     regex
   end
+
+  @spec maybe_filter_empties([String.t], Keyword.t) :: [String.t]
+  defp maybe_filter_empties(list, :zero_or_more) do
+    Enum.filter(list, &(&1 != ""))
+  end
+  defp maybe_filter_empties(list, _), do: list
+
+  defp join_with_quantifier(list, :zero_or_more), do: Enum.join(list, ".*")
+  defp join_with_quantifier(list, :one), do: Enum.join(list, ".")
+  defp join_with_quantifier(list, _), do: Enum.join(list, ".+")
 end

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Wildcard.Mixfile do
   def project do
     [
       app: :wildcard,
-      version: "0.1.0",
+      version: "0.2.0",
       elixir: "~> 1.3",
       build_embedded: Mix.env == :prod,
       start_permanent: Mix.env == :prod,

--- a/test/wildcard_to_regex_test.exs
+++ b/test/wildcard_to_regex_test.exs
@@ -21,8 +21,23 @@ defmodule WildcardTest do
       assert to_regex("cat.dog/+") == ~r/cat\.dog\/\+/
     end
 
+    test "generates regex matching zero or more if the match_type is :zero_or_more" do
+      assert to_regex("cat*dog", match_type: :zero_or_more) == ~r/cat.*dog/
+    end
+
     test "treats consecutive wildcards as one if the match_type is :zero_or_more" do
       assert to_regex("cat***dog", match_type: :zero_or_more) == ~r/cat.*dog/
     end
+
+    test "does not treat consecutive wildcards as one if match type is :one_or_more" do
+      assert to_regex("cat**dog")                           == ~r/cat.+.+dog/
+      assert to_regex("cat**dog", match_type: :one_or_more) == ~r/cat.+.+dog/
+    end
+
+    test "genereates a regex matching one character if match_type is :one" do
+      assert to_regex("cat*dog", match_type: :one)  == ~r/cat.dog/
+      assert to_regex("cat**dog", match_type: :one) == ~r/cat..dog/
+    end
+
   end
 end

--- a/test/wildcard_to_regex_test.exs
+++ b/test/wildcard_to_regex_test.exs
@@ -14,15 +14,15 @@ defmodule WildcardTest do
     end
 
     test "converts a string containing a wildcard to the appropriate regex" do
-      assert to_regex("cat*dog") == ~r/cat.*dog/
+      assert to_regex("cat*dog") == ~r/cat.+dog/
     end
 
     test "properly escapes a string containing a special regex operator" do
       assert to_regex("cat.dog/+") == ~r/cat\.dog\/\+/
     end
 
-    test "treats consecutive wildcards as one" do
-      assert to_regex("cat***dog") == ~r/cat.*dog/
+    test "treats consecutive wildcards as one if the match_type is :zero_or_more" do
+      assert to_regex("cat***dog", match_type: :zero_or_more) == ~r/cat.*dog/
     end
   end
 end


### PR DESCRIPTION
Adds options to the `to_regex/2` function.

Adds the `:match_type` option which allows the specification of how many characters a wildcard should match for a given expression.

Updates documentation to include options.

Bump version to 0.2.0.